### PR TITLE
Fix edit command allowing duplicate policy names

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -21,6 +21,8 @@ public class Messages {
                 "Multiple values specified for the following single-valued field(s): ";
     public static final String MESSAGE_INVALID_POLICY_FORMAT = "Invalid policy format!";
     public static final String MESSAGE_INVALID_POLICY_DISPLAYED_INDEX = "The policy index provided is invalid";
+    public static final String MESSAGE_DUPLICATE_POLICY_NAME = "The policy name provided is duplicated";
+    public static final String MESSAGE_DUPLICATE_POLICY_INDEX = "Multiple identical policy index specified to edit";
 
     /**
      * Returns an error message indicating the duplicate prefixes.

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -141,15 +141,47 @@ public class EditCommand extends Command {
         for (Map.Entry<Index, Policy> entry : newPolicies.entrySet()) {
             Index index = entry.getKey();
             Policy policy = entry.getValue();
+            int zeroBasedIndex = index.getZeroBased();
 
-            if (index.getZeroBased() >= policiesSize) {
+            if (zeroBasedIndex >= policiesSize) {
                 throw new CommandException(Messages.MESSAGE_INVALID_POLICY_DISPLAYED_INDEX);
             }
 
-            updatedPolicies.set(index.getZeroBased(), policy);
+            int duplicatePolicyIndex = getDuplicatePolicyIndex(policy, updatedPolicies);
+            boolean isPolicyToEdit = (duplicatePolicyIndex == zeroBasedIndex);
+            boolean isNotDuplicatePolicy = (duplicatePolicyIndex == -1);
+
+            if (!isNotDuplicatePolicy && !isPolicyToEdit) {
+                throw new CommandException(Messages.MESSAGE_DUPLICATE_POLICY_NAME);
+            }
+
+            updatedPolicies.set(zeroBasedIndex, policy);
         }
 
         return updatedPolicies;
+    }
+
+    /**
+     * Checks if a given policy already exists in the provided list of policies. If a policy with the same name is
+     * found, the method returns the index of the matching policy in the list. If no matching policy is found, it
+     * returns {@code -1}.
+     *
+     * @param policy      the {@link Policy} object to check for duplication
+     * @param policyList  the list of {@link Policy} objects to compare against
+     * @return the index of the duplicate policy in the list, or {@code -1} if
+     *         no duplicate is found
+     */
+    public static Integer getDuplicatePolicyIndex(Policy policy, List<Policy> policyList) {
+        String policyName = policy.getPolicyName();
+        int size = policyList.size();
+
+        for (int i = 0; i < size; i++) {
+            if (policyName.equals(policyList.get(i).getPolicyName())) {
+                return i;
+            }
+        }
+
+        return -1;
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -49,7 +49,7 @@ public class EditCommandParser implements Parser<EditCommand> {
         }
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
-                PREFIX_BIRTHDAY, PREFIX_ADDRESS, PREFIX_POLICY);
+                PREFIX_BIRTHDAY, PREFIX_ADDRESS);
 
         EditPersonDescriptor editPersonDescriptor = new EditPersonDescriptor();
 

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.Messages.MESSAGE_DUPLICATE_POLICY_INDEX;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_POLICY_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NEXT_PAYMENT_DATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PAYMENT_AMOUNT;
@@ -218,6 +219,7 @@ public class ParserUtil {
     public static Map<Index, Policy> parsePolicies(Collection<String> policies) throws ParseException {
         requireNonNull(policies);
         final Map<Index, Policy> policyMap = new HashMap<>();
+        final Set<Integer> toEditIndexSet = new HashSet<>();
 
         for (String policyArgs : policies) {
             String trimmedPolicy = policyArgs.trim();
@@ -233,6 +235,11 @@ public class ParserUtil {
                 throw new ParseException(String.format(MESSAGE_INVALID_POLICY_FORMAT), pe);
             }
 
+            if (toEditIndexSet.contains(index.getZeroBased())) {
+                throw new ParseException(MESSAGE_DUPLICATE_POLICY_INDEX);
+            }
+
+            toEditIndexSet.add(index.getZeroBased());
             policyMap.put(index, parsePolicy(policyArgs));
         }
 

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -75,7 +75,9 @@ public class CommandTestUtil {
     public static final String EDIT_POLICY_LIFE_1 = " 1 "
             + PREFIX_POLICY_NAME + VALID_POLICY_NAME_LIFE + " "
             + PREFIX_POLICY_START_DATE + VALID_DATE_1 + " "
-            + PREFIX_POLICY_END_DATE + VALID_DATE_2;
+            + PREFIX_POLICY_END_DATE + VALID_DATE_2 + " "
+            + PREFIX_NEXT_PAYMENT_DATE + VALID_INSURANCE_PAYMENT_DATE + " "
+            + PREFIX_PAYMENT_AMOUNT + VALID_INSURANCE_AMOUNT_DUE;
     public static final String VALID_EDIT_POLICY_LIFE = " " + PREFIX_POLICY + EDIT_POLICY_LIFE_1;
     public static final String VALID_ASSIGN_POLICY = " " + PREFIX_POLICY_NAME + VALID_POLICY_NAME_LIFE
             + PREFIX_POLICY_START_DATE + VALID_DATE_1 + " " + PREFIX_POLICY_END_DATE + VALID_DATE_2 + " "

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -173,7 +173,55 @@ public class EditCommandTest {
     }
 
     @Test
+    public void editPolicies_invalidDuplicatePolicyName_throwsCommandException() {
+        Person personToEdit = new PersonBuilder().build();
+        Policy oldPolicy1 = new Policy(VALID_NAME_BOB, VALID_DATE_1, VALID_DATE_2, VALID_INSURANCE_PAYMENT);
+        Policy oldPolicy2 = new Policy(VALID_POLICY_NAME_LIFE, VALID_DATE_1, VALID_DATE_2, VALID_INSURANCE_PAYMENT);
+        List<Policy> oldPolicyList = new ArrayList<>();
+        oldPolicyList.add(oldPolicy1);
+        oldPolicyList.add(oldPolicy2);
+        personToEdit.setPolicies(oldPolicyList);
+
+        Policy duplicateNamePolicy =
+                new Policy(VALID_POLICY_NAME_LIFE, VALID_DATE_1, VALID_DATE_2, VALID_INSURANCE_PAYMENT);
+        Index validIndex = Index.fromOneBased(1);
+
+        Map<Index, Policy> policyMap = new HashMap<>();
+        policyMap.put(validIndex, duplicateNamePolicy);
+
+        assertThrows(CommandException.class, () -> EditCommand.editPolicies(personToEdit, policyMap));
+    }
+
+    @Test
     public void editPolicies_validPolicyMap_returnsPolicyList() throws CommandException {
+        Person personToEdit = new PersonBuilder().build();
+        Policy oldPolicy1 = new Policy(VALID_NAME_BOB, VALID_DATE_1, VALID_DATE_2, VALID_INSURANCE_PAYMENT);
+        Policy oldPolicy2 = new Policy(VALID_POLICY_NAME_LIFE, VALID_DATE_1, VALID_DATE_2, VALID_INSURANCE_PAYMENT);
+        List<Policy> oldPolicyList = new ArrayList<>();
+        oldPolicyList.add(oldPolicy1);
+        oldPolicyList.add(oldPolicy2);
+        personToEdit.setPolicies(oldPolicyList);
+
+        Policy validPolicy = new Policy(VALID_NAME_AMY, VALID_DATE_1, VALID_DATE_2, VALID_INSURANCE_PAYMENT);
+
+        Index validIndex = Index.fromOneBased(2);
+
+        Map<Index, Policy> policyMap = new HashMap<>();
+        policyMap.put(validIndex, validPolicy);
+
+        List<Policy> expectedPolicyList = new ArrayList<>();
+        expectedPolicyList.add(oldPolicy1);
+        expectedPolicyList.add(validPolicy);
+
+        expectedPolicyList.sort(Comparator.comparing(Policy::getPolicyPaymentDueDate));
+
+        personToEdit.setPolicies(expectedPolicyList);
+
+        assertEquals(expectedPolicyList, EditCommand.editPolicies(personToEdit, policyMap));
+    }
+
+    @Test
+    public void editPolicies_validPolicyMapChangePolicyName_returnsPolicyList() throws CommandException {
         Person personToEdit = new PersonBuilder().build();
         Policy oldPolicy = new Policy(VALID_NAME_BOB, VALID_DATE_1, VALID_DATE_2, VALID_INSURANCE_PAYMENT);
         personToEdit.setPolicies(List.of(oldPolicy));

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -278,17 +278,36 @@ public class ParserUtilTest {
     public void parsePolicies_invalidIndex_throwsParseException() throws ParseException {
         String policyArgumentWithInvalidIndex = "c " + PREFIX_POLICY_NAME + VALID_POLICY_NAME + " "
                 + PREFIX_POLICY_START_DATE + VALID_DATE_1 + " "
-                + PREFIX_POLICY_END_DATE + VALID_DATE_2;
+                + PREFIX_POLICY_END_DATE + VALID_DATE_2 + " "
+                + PREFIX_NEXT_PAYMENT_DATE + VALID_INSURANCE_PAYMENT_DATE + " "
+                + PREFIX_PAYMENT_AMOUNT + VALID_INSURANCE_AMOUNT_DUE;
+
         Collection<String> policies = List.of(policyArgumentWithInvalidIndex, EDIT_POLICY_LIFE_1);
+
+        assertThrows(ParseException.class, () -> ParserUtil.parsePolicies(policies));
+    }
+
+    @Test
+    public void parsePolicies_invalidDuplicateIndex_throwsParseException() throws ParseException {
+        String policyArgumentWithDuplicateIndex = "1 " + PREFIX_POLICY_NAME + VALID_POLICY_NAME + " "
+                + PREFIX_POLICY_START_DATE + VALID_DATE_1 + " "
+                + PREFIX_POLICY_END_DATE + VALID_DATE_2 + " "
+                + PREFIX_NEXT_PAYMENT_DATE + VALID_INSURANCE_PAYMENT_DATE + " "
+                + PREFIX_PAYMENT_AMOUNT + VALID_INSURANCE_AMOUNT_DUE;
+
+        Collection<String> policies = List.of(EDIT_POLICY_LIFE_1, policyArgumentWithDuplicateIndex);
 
         assertThrows(ParseException.class, () -> ParserUtil.parsePolicies(policies));
     }
     @Test
     public void parsePolicies_invalidArgumentWithNoName_throwsParseException() throws ParseException {
-        String policyArgumentWithInvalidIndex = "1 "
+        String policyArgumentWithNoName = "2 "
                 + PREFIX_POLICY_START_DATE + VALID_DATE_1 + " "
-                + PREFIX_POLICY_END_DATE + VALID_DATE_2;
-        Collection<String> policies = List.of(policyArgumentWithInvalidIndex, EDIT_POLICY_LIFE_1);
+                + PREFIX_POLICY_END_DATE + VALID_DATE_2 + " "
+                + PREFIX_NEXT_PAYMENT_DATE + VALID_INSURANCE_PAYMENT_DATE + " "
+                + PREFIX_PAYMENT_AMOUNT + VALID_INSURANCE_AMOUNT_DUE;
+
+        Collection<String> policies = List.of(policyArgumentWithNoName, EDIT_POLICY_LIFE_1);
 
         assertThrows(ParseException.class, () -> ParserUtil.parsePolicies(policies));
     }


### PR DESCRIPTION
The edit command fails to correctly identify duplicate policy names, allowing policies tho share the same name using edit command.

Handling the duplication of policy name in edit command prevents possible error cause by having multiple policies with same name.

Let's implements a check to ensure that duplicate policy names are detected properly and display an error to inform the user.